### PR TITLE
Update translators.py to add user-agent header

### DIFF
--- a/src/jsonschema2ddl/translators.py
+++ b/src/jsonschema2ddl/translators.py
@@ -70,9 +70,9 @@ class JSONSchemaToDatabase:
             jsonschema.ValidationError: Schema is invalid
         """
         metaschema_uri = self.schema.get("$schema", "https://json-schema.org/draft-07/schema")
-        metaschema_uri = urlopen(metaschema_uri).url
+        r = Request(metaschema_uri, headers={'User-Agent': 'Mozilla/5.0'})
 
-        meta_schema = json.loads(urlopen(metaschema_uri).read())
+        meta_schema = json.loads(urlopen(r).read())
         jsonschema.validate(instance=self.schema, schema=meta_schema)
         self.logger.debug("Schema is valid")
 


### PR DESCRIPTION
urllib3 appears to require that a user-agent header be provided, otherwise the call for the schema is denied at `json.loads` in the `_validate_schema` func of `translators.py`, presumably because the endpoint (`https://json-schema.org/draft-07/schema`) sees the missing user-agent header as an indicator of bot activity.